### PR TITLE
Update to 1.9.4 with an additional change to axe creation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     repositories {
-        mavenCentral()
+        jcenter()
         maven {
             name = "forge"
             url = "http://files.minecraftforge.net/maven"
@@ -11,10 +11,11 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'net.minecraftforge.gradle:ForgeGradle:1.2-SNAPSHOT'
+        classpath 'net.minecraftforge.gradle:ForgeGradle:2.2-SNAPSHOT'
         classpath group: 'com.github.rodionmoiseev.gradle.plugins', name: 'idea-utils', version: '0.2'
     }
 }
+
 
 import groovy.json.*
 
@@ -23,8 +24,7 @@ configurations {
     deployJars
 }
 
-apply plugin: "forge"
-apply plugin: "maven"
+apply plugin: "net.minecraftforge.gradle.forge"
 apply plugin: "idea-utils"
 
 group = "net.doubledoordev.lumberjack"
@@ -37,8 +37,9 @@ archivesBaseName = 'Lumberjack'
 def githuborg = 'DoubleDoorDevelopment'
 def description = 'Boom. Tree gone!'
 minecraft {
-    version = "1.7.10-10.13.0.1190"
+    version = "1.9.4-12.17.0.1909-1.9.4"
     runDir = "jars"
+    mappings = "snapshot_20160518"    
 }
 
 repositories {
@@ -54,7 +55,7 @@ dependencies {
 
 if (System.getenv().BUILD_NUMBER != null) version += "." + System.getenv().BUILD_NUMBER
 def builder = new groovy.json.JsonBuilder()
-builder (version: version, mcversion: project.minecraft.version, apiversion: project.minecraft.apiVersion)
+builder (version: version, mcversion: project.minecraft.version, apiversion: project.minecraft.mcpVersion)
 new File("versions.json").write(builder.toPrettyString())
 
 processResources {

--- a/src/main/java/net/doubledoordev/lumberjack/Lumberjack.java
+++ b/src/main/java/net/doubledoordev/lumberjack/Lumberjack.java
@@ -186,12 +186,12 @@ public class Lumberjack implements ID3Mod
                     Point newPoint = new Point(newX, newY, newZ);
                     if (nextMap.containsEntry(name, newPoint) || pointMap.containsEntry(name, newPoint)) continue;
 
-                    Block newBlock = event.getWorld().getBlockState(new BlockPos(newX,newY,newZ)).getBlock();
                     IBlockState newBlockState = event.getWorld().getBlockState(new BlockPos(newX, newY, newZ));
                     switch (mode)
                     {
                         case 0:
-                            if (!(newBlockState == event.getState() || (leaves && newBlockState.getMaterial() == Material.LEAVES))) continue;
+
+                            if (!(newBlockState.getBlock() == event.getState().getBlock() || (leaves && newBlockState.getMaterial() == Material.LEAVES))) continue;
                             break;
 
                         case 1:

--- a/src/main/java/net/doubledoordev/lumberjack/Lumberjack.java
+++ b/src/main/java/net/doubledoordev/lumberjack/Lumberjack.java
@@ -45,7 +45,7 @@ import net.doubledoordev.d3core.util.ID3Mod;
 import net.doubledoordev.lumberjack.Proxy.IProxy;
 import net.doubledoordev.lumberjack.items.ItemLumberAxe;
 import net.doubledoordev.lumberjack.util.Point;
-
+import net.minecraft.block.state.IBlockState;
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.entity.player.EntityPlayerMP;
@@ -187,14 +187,15 @@ public class Lumberjack implements ID3Mod
                     if (nextMap.containsEntry(name, newPoint) || pointMap.containsEntry(name, newPoint)) continue;
 
                     Block newBlock = event.getWorld().getBlockState(new BlockPos(newX,newY,newZ)).getBlock();
+                    IBlockState newBlockState = event.getWorld().getBlockState(new BlockPos(newX, newY, newZ));
                     switch (mode)
                     {
                         case 0:
-                            if (!(newBlock.equals(event.getState().getBlock()) || (leaves && newBlock.getMaterial(event.getState()).equals(Material.LEAVES)))) continue;
+                            if (!(newBlockState == event.getState() || (leaves && newBlockState.getMaterial() == Material.LEAVES))) continue;
                             break;
 
                         case 1:
-                            if (!(newBlock.getMaterial(event.getState()).equals(Material.WOOD) || (leaves && newBlock.getMaterial(event.getState()).equals(Material.LEAVES)))) continue;
+                            if (!(newBlockState.getMaterial() == Material.WOOD || (leaves && newBlockState.getMaterial() == Material.LEAVES)))
                             break;
                     }
 

--- a/src/main/java/net/doubledoordev/lumberjack/Lumberjack.java
+++ b/src/main/java/net/doubledoordev/lumberjack/Lumberjack.java
@@ -32,28 +32,38 @@ package net.doubledoordev.lumberjack;
 
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableSet;
-import cpw.mods.fml.client.config.IConfigElement;
-import cpw.mods.fml.common.FMLCommonHandler;
-import cpw.mods.fml.common.Mod;
-import cpw.mods.fml.common.event.FMLInitializationEvent;
-import cpw.mods.fml.common.event.FMLPreInitializationEvent;
-import cpw.mods.fml.common.eventhandler.SubscribeEvent;
-import cpw.mods.fml.common.gameevent.TickEvent;
+import net.minecraftforge.fml.client.config.IConfigElement;
+import net.minecraftforge.fml.common.FMLCommonHandler;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.SidedProxy;
+import net.minecraftforge.fml.common.event.FMLInitializationEvent;
+import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.common.gameevent.TickEvent;
 import net.doubledoordev.d3core.D3Core;
 import net.doubledoordev.d3core.util.ID3Mod;
+import net.doubledoordev.lumberjack.Proxy.IProxy;
 import net.doubledoordev.lumberjack.items.ItemLumberAxe;
 import net.doubledoordev.lumberjack.util.Point;
+
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
+import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.math.BlockPos;
+
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.config.ConfigElement;
 import net.minecraftforge.common.config.Configuration;
 import net.minecraftforge.event.world.BlockEvent;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
+
 import org.apache.logging.log4j.Logger;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 
@@ -67,6 +77,9 @@ public class Lumberjack implements ID3Mod
 {
     @Mod.Instance(MODID)
     public static Lumberjack instance;
+
+    @SidedProxy(clientSide = "net.doubledoordev.lumberjack.Proxy.ClientProxy", serverSide = "net.doubledoordev.lumberjack.Proxy.CommonProxy")
+    public static IProxy proxy;
     public Logger logger;
 
     public int                         limit    = 1024;
@@ -75,6 +88,7 @@ public class Lumberjack implements ID3Mod
     public HashMultimap<String, Point> pointMap = HashMultimap.create();
     public HashMultimap<String, Point> nextMap  = HashMultimap.create();
     private Configuration configuration;
+    private static ArrayList<ItemLumberAxe> lumberAxes = new ArrayList<>();
 
     @Mod.EventHandler
     public void preInit(FMLPreInitializationEvent event)
@@ -91,25 +105,25 @@ public class Lumberjack implements ID3Mod
     public void init(FMLInitializationEvent event)
     {
         if (D3Core.debug()) logger.info("Registering all tools");
-        HashSet<Item> items = new HashSet<>(Item.ToolMaterial.values().length);
+        HashSet<ItemStack> itemStack = new HashSet<>(Item.ToolMaterial.values().length);
         for (Item.ToolMaterial material : Item.ToolMaterial.values())
         {
             try
             {
-                if (material.func_150995_f() == null)
+                if (material.getRepairItemStack() == null)
                 {
-                    if (D3Core.debug()) logger.warn("The ToolMaterial " + material + " doesn't have a crafting item set. No LumberAxe from that!");
+                    if (D3Core.debug()) logger.warn("The ToolMaterial " + material + " doesn't have a crafting itemstack set. No LumberAxe from that!");
                 }
-                else if (items.contains(material.func_150995_f()))
+                else if (itemStack.contains(material.getRepairItemStack()))
                 {
-                    if (D3Core.debug()) logger.warn("The ToolMaterial " + material + " uses an item that has already been used.");
+                    if (D3Core.debug()) logger.warn("The ToolMaterial " + material + " uses an itemStack that has already been used.");
                 }
                 else
                 {
                     try
                     {
-                        new ItemLumberAxe(material);
-                        items.add(material.func_150995_f());
+                        lumberAxes.add(new ItemLumberAxe(material));
+                        itemStack.add(material.getRepairItemStack());
                     }
                     catch (Exception e)
                     {
@@ -130,6 +144,8 @@ public class Lumberjack implements ID3Mod
                     new TableData("Item name", ItemLumberAxe.itemNames),
                     new TableData("Crafting Items", ItemLumberAxe.craftingItems)));
         }
+
+        proxy.registerItemRenders(event);
     }
 
     @SubscribeEvent
@@ -138,11 +154,11 @@ public class Lumberjack implements ID3Mod
         if (event.phase != TickEvent.Phase.START) return;
         if (!event.side.isServer()) return;
 
-        String name = event.player.getCommandSenderName();
+        String name = event.player.getCommandSenderEntity().getName();
         if (!nextMap.containsKey(name) || nextMap.get(name).isEmpty()) return;
         for (Point point : ImmutableSet.copyOf(nextMap.get(name)))
         {
-            ((EntityPlayerMP) event.player).theItemInWorldManager.tryHarvestBlock(point.x, point.y, point.z);
+            ((EntityPlayerMP) event.player).interactionManager.tryHarvestBlock(new BlockPos(point.x, point.y, point.z));
             nextMap.remove(name, point);
             if (pointMap.get(name).size() > limit) nextMap.removeAll(name);
         }
@@ -153,13 +169,12 @@ public class Lumberjack implements ID3Mod
     public void breakEvent(BlockEvent.BreakEvent event)
     {
         if (event.getPlayer() == null) return;
-        if (!(event.block.getMaterial() == Material.wood || (leaves && event.block.getMaterial() == Material.leaves))) return;
-
-        ItemStack itemStack = event.getPlayer().getHeldItem();
+        if (!(event.getState().getMaterial() == Material.WOOD || (leaves && event.getState().getMaterial() == Material.LEAVES))) return;
+        ItemStack itemStack = event.getPlayer().getHeldItemMainhand();
         if (itemStack == null || !(itemStack.getItem() instanceof ItemLumberAxe)) return;
 
-        String name = event.getPlayer().getCommandSenderName();
-        pointMap.put(name, new Point(event.x, event.y, event.z));
+        String name = event.getPlayer().getCommandSenderEntity().getName();
+        pointMap.put(name, new Point(event.getPos().getX(), event.getPos().getY(), event.getPos().getZ()));
 
         for (int offsetX = -1; offsetX <= 1; offsetX++)
         {
@@ -167,22 +182,22 @@ public class Lumberjack implements ID3Mod
             {
                 for (int offsetY = -1; offsetY <= 1; offsetY++)
                 {
-                    int newX = event.x + offsetX;
-                    int newY = event.y + offsetY;
-                    int newZ = event.z + offsetZ;
+                    int newX = event.getPos().getX() + offsetX;
+                    int newY = event.getPos().getY() + offsetY;
+                    int newZ = event.getPos().getZ() + offsetZ;
 
                     Point newPoint = new Point(newX, newY, newZ);
                     if (nextMap.containsEntry(name, newPoint) || pointMap.containsEntry(name, newPoint)) continue;
 
-                    Block newBlock = event.world.getBlock(newX, newY, newZ);
+                    Block newBlock = event.getWorld().getBlockState(new BlockPos(newX,newY,newZ)).getBlock();
                     switch (mode)
                     {
                         case 0:
-                            if (!(newBlock == event.block || (leaves && newBlock.getMaterial() == Material.leaves))) continue;
+                            if (!(newBlock.equals(event.getState().getBlock()) || (leaves && newBlock.getMaterial(event.getState()).equals(Material.LEAVES)))) continue;
                             break;
 
                         case 1:
-                            if (!(newBlock.getMaterial() == Material.wood || (leaves && newBlock.getMaterial() == Material.leaves))) continue;
+                            if (!(newBlock.getMaterial(event.getState()).equals(Material.WOOD) || (leaves && newBlock.getMaterial(event.getState()).equals(Material.LEAVES)))) continue;
                             break;
                     }
 
@@ -207,5 +222,10 @@ public class Lumberjack implements ID3Mod
     public void addConfigElements(List<IConfigElement> configElements)
     {
         configElements.add(new ConfigElement(configuration.getCategory(MODID.toLowerCase())));
+    }
+
+    public static ArrayList<ItemLumberAxe> getLumberAxes()
+    {
+        return lumberAxes;
     }
 }

--- a/src/main/java/net/doubledoordev/lumberjack/Lumberjack.java
+++ b/src/main/java/net/doubledoordev/lumberjack/Lumberjack.java
@@ -48,7 +48,6 @@ import net.doubledoordev.lumberjack.util.Point;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
-import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
@@ -58,8 +57,6 @@ import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.config.ConfigElement;
 import net.minecraftforge.common.config.Configuration;
 import net.minecraftforge.event.world.BlockEvent;
-import net.minecraftforge.fml.relauncher.Side;
-import net.minecraftforge.fml.relauncher.SideOnly;
 
 import org.apache.logging.log4j.Logger;
 

--- a/src/main/java/net/doubledoordev/lumberjack/Proxy/ClientProxy.java
+++ b/src/main/java/net/doubledoordev/lumberjack/Proxy/ClientProxy.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2014, DoubleDoorDevelopment
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ *  Neither the name of the project nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package net.doubledoordev.lumberjack.Proxy;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.RenderItem;
+import net.minecraft.client.renderer.block.model.ModelResourceLocation;
+
+import net.minecraftforge.fml.common.event.FMLInitializationEvent;
+
+import net.doubledoordev.lumberjack.Lumberjack;
+import net.doubledoordev.lumberjack.items.ItemLumberAxe;
+
+public class ClientProxy extends CommonProxy{
+
+	@Override
+	public void registerItemRenders(FMLInitializationEvent event) {
+
+		String axeName;
+		RenderItem renderItem = Minecraft.getMinecraft().getRenderItem();
+		ModelResourceLocation lumberaxeMRL;
+		for(ItemLumberAxe axe: Lumberjack.getLumberAxes())
+		{
+			axeName = axe.getUnlocalizedName().substring(14);
+			lumberaxeMRL = new ModelResourceLocation("lumberjack:lumberaxe"+axeName,"inventory");
+			renderItem.getItemModelMesher().register(axe,0,lumberaxeMRL);
+		}
+
+
+
+	}
+}

--- a/src/main/java/net/doubledoordev/lumberjack/Proxy/CommonProxy.java
+++ b/src/main/java/net/doubledoordev/lumberjack/Proxy/CommonProxy.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2014, DoubleDoorDevelopment
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ *  Neither the name of the project nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package net.doubledoordev.lumberjack.Proxy;
+
+import net.minecraftforge.fml.common.event.FMLInitializationEvent;
+
+public class CommonProxy implements IProxy{
+
+	@Override
+	public void registerItemRenders(FMLInitializationEvent event) {}
+
+}

--- a/src/main/java/net/doubledoordev/lumberjack/Proxy/IProxy.java
+++ b/src/main/java/net/doubledoordev/lumberjack/Proxy/IProxy.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2014, DoubleDoorDevelopment
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ *  Neither the name of the project nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package net.doubledoordev.lumberjack.Proxy;
+
+import net.minecraftforge.fml.common.event.FMLInitializationEvent;
+
+public interface IProxy {
+
+	void registerItemRenders(FMLInitializationEvent event);
+}

--- a/src/main/java/net/doubledoordev/lumberjack/items/ItemLumberAxe.java
+++ b/src/main/java/net/doubledoordev/lumberjack/items/ItemLumberAxe.java
@@ -45,9 +45,6 @@ import net.minecraftforge.oredict.ShapedOreRecipe;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 
-import net.doubledoordev.lumberjack.Lumberjack;
-import static net.doubledoordev.lumberjack.util.Constants.MODID;
-
 /**
  * @author Dries007
  */

--- a/src/main/java/net/doubledoordev/lumberjack/items/ItemLumberAxe.java
+++ b/src/main/java/net/doubledoordev/lumberjack/items/ItemLumberAxe.java
@@ -30,13 +30,14 @@
 
 package net.doubledoordev.lumberjack.items;
 
-import cpw.mods.fml.common.registry.GameRegistry;
-import net.minecraft.block.Block;
+import net.minecraftforge.fml.common.registry.GameRegistry;
 import net.minecraft.block.material.Material;
+import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.ItemAxe;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.ItemTool;
+import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraftforge.oredict.OreDictionary;
 import net.minecraftforge.oredict.ShapedOreRecipe;
@@ -44,6 +45,7 @@ import net.minecraftforge.oredict.ShapedOreRecipe;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 
+import net.doubledoordev.lumberjack.Lumberjack;
 import static net.doubledoordev.lumberjack.util.Constants.MODID;
 
 /**
@@ -67,21 +69,21 @@ public class ItemLumberAxe extends ItemAxe
         super(toolMaterial);
 
         String name = toolMaterial.name().toLowerCase();
-        if (toolMaterial == ToolMaterial.EMERALD) name = "diamond";
+        if (toolMaterial == ToolMaterial.DIAMOND) name = "diamond";
 
         //Fuck mods that do this: "modid_nameofmaterial"
         if (name.indexOf('_') != -1) name = name.substring(name.indexOf('_') + 1);
         if (name.indexOf('|') != -1) name = name.substring(name.indexOf('|') + 1);
         if (name.indexOf(':') != -1) name = name.substring(name.indexOf(':') + 1);
 
-        setTextureName(MODID + ":" + name + "_lumberaxe");
         name = "lumberaxe" + Character.toUpperCase(name.charAt(0)) + name.substring(1);
         setUnlocalizedName(name);
-        GameRegistry.registerItem(this, name);
+
 
         toolMaterials.add(toolMaterial.toString());
-        textureStrings.add(iconString);
         itemNames.add(name);
+
+        GameRegistry.registerItem(this,name);
 
         try
         {
@@ -93,7 +95,7 @@ public class ItemLumberAxe extends ItemAxe
         }
 
         String items = "";
-        ItemStack craftingItem = new ItemStack(toolMaterial.func_150995_f());
+        ItemStack craftingItem = toolMaterial.getRepairItemStack().copy();
         int[] ids = OreDictionary.getOreIDs(craftingItem);
         if (ids.length == 0)
         {
@@ -112,8 +114,8 @@ public class ItemLumberAxe extends ItemAxe
     }
 
     @Override
-    public boolean onBlockDestroyed(ItemStack itemStack, World world, Block block, int x, int y, int z, EntityLivingBase entityLivingBase)
+    public boolean onBlockDestroyed(ItemStack itemStack, World world, IBlockState state, BlockPos blockPos, EntityLivingBase entityLivingBase)
     {
-        return block.getMaterial() == Material.leaves || super.onBlockDestroyed(itemStack, world, block, x, y, z, entityLivingBase);
+        return state.getBlock().getMaterial(state).equals(Material.LEAVES) || super.onBlockDestroyed(itemStack, world, state, blockPos, entityLivingBase);
     }
 }


### PR DESCRIPTION
I've updated D3Core and Lumberjack to 1.9.4 for my personal use and have been convinced I should share what work I've done.

This is not a direct port to 1.9.4. I have also changed the Lumberaxe creation process to be based off of unique ItemStacks rather than Items. This allows ToolMaterials that share the same repairItem but that have unique repairItemStacks to be registered for Lumberaxes.

Initially built against 1.9.4, it does run on 1.10.2 after some very light testing on my end.
